### PR TITLE
Stop appending hyphen to file link

### DIFF
--- a/src/Impl/CopyGitLink.Shared/Core/GitOnlineServices/GitHubnLab.cs
+++ b/src/Impl/CopyGitLink.Shared/Core/GitOnlineServices/GitHubnLab.cs
@@ -92,13 +92,16 @@ namespace CopyGitLink.Shared.Core.GitOnlineServices
                 url += $"#L{startLineNumber + 1}";
             }
 
-            if (endLineNumber.HasValue && host.Contains("github"))
+            if (endLineNumber.HasValue)
             {
-                url += $"-L{endLineNumber + 1}";
-            }
-            else
-            {
-                url += $"-{endLineNumber + 1}";
+                if (host.Contains("github"))
+                {
+                    url += $"-L{endLineNumber + 1}";
+                }
+                else
+                {
+                    url += $"-{endLineNumber + 1}";
+                }
             }
 
             return url;


### PR DESCRIPTION
Fixes issue where copying a link just to a file (from solution explorer or tab context menu) appends a hyphen to the link

Only add hypen when there's an endLineNumber

Marked as draft since it is totally untested and could probably do with a test case adding. I'll try to come back and finish it off later when I have time.